### PR TITLE
Add PolicyFoo, edit ControllerContainerBlockSSHPort

### DIFF
--- a/policies/ControllerContainerBlockSSHPort/README.md
+++ b/policies/ControllerContainerBlockSSHPort/README.md
@@ -1,3 +1,5 @@
+Foo
+
 # Containers Block SSH Port
 
 This Policy checks if the container is exposing ssh port.

--- a/policies/PolicyFoo/readme.md
+++ b/policies/PolicyFoo/readme.md
@@ -1,0 +1,1 @@
+Foo bar baz


### PR DESCRIPTION
This PR adds new PolicyFoo, edits ControllerContainerBlockSSHPort.

In this PR, we shall see the CI workflow run where first the list of policies is calculated.

Then a matrix of test-policy-rego jobs should be started:
- 2 jobs for ControllerContainerBLockSSHPort (unit-tests and check-artifacthub): both should pass.
- 2 jobs for PolicyFoo (unit-tests and check-artifacthub): both expected to fail, as the folder is empty.